### PR TITLE
Add support for arrays of Links

### DIFF
--- a/lib/hyperclient/link_collection.rb
+++ b/lib/hyperclient/link_collection.rb
@@ -13,13 +13,24 @@ module Hyperclient
     # Public: Initializes a LinkCollection.
     #
     # collection  - The Hash with the links.
-    # entry_point - The EntryPoint object to inject the cofnigutation.
+    # entry_point - The EntryPoint object to inject the configuration.
     #
     def initialize(collection, entry_point)
-      raise "Invalid response for LinkCollection. The response was: #{collection.inspect}" if collection && !collection.respond_to?(:inject)
-      @collection = (collection || {}).inject({}) do |hash, (name, link)|
-        hash.update(name => Link.new(link, entry_point))
-      end
+      raise "Invalid response for LinkCollection. The response was: #{collection.inspect}" if collection && !collection.respond_to?(:collect)
+
+      @collection = Hash[
+        (collection || {}).collect do |name, link_or_links|
+          value = if link_or_links.class == Array
+            link_or_links.collect do |link|
+              Link.new(link, entry_point)
+            end
+          else
+            Link.new(link_or_links, entry_point)
+          end
+
+          [name, value]
+        end
+      ]
     end
   end
 end

--- a/test/fixtures/element.json
+++ b/test/fixtures/element.json
@@ -6,7 +6,15 @@
         "filter": {
             "href": "/productions/1?categories={filter}",
             "templated": true
-        }
+        },
+        "gizmos": [
+            {
+                "href": "/gizmos/1"
+            },
+            {
+                "href": "/gizmos/2"
+            }
+        ]
     },
     "title": "Real World ASP.NET MVC3",
     "description": "In this advanced, somewhat-opinionated production you'll get your very own startup off the ground using ASP.NET MVC 3...",

--- a/test/hyperclient/link_collection_test.rb
+++ b/test/hyperclient/link_collection_test.rb
@@ -19,11 +19,29 @@ module Hyperclient
 
     it 'initializes the collection with links' do
       links.must_respond_to :filter
+      links.must_respond_to :gizmos
     end
 
     it 'returns link objects for each link' do
       links.filter.must_be_kind_of Link
       links['self'].must_be_kind_of Link
+
+      links.gizmos.must_be_kind_of Array
+      links['gizmos'].must_be_kind_of Array
+    end
+
+    describe "array of links" do
+      let(:gizmos) { links.gizmos }
+
+      it 'should have 2 items' do
+        gizmos.length.must_equal 2
+      end
+
+      it 'must be an array of Links' do
+        gizmos.each do |link|
+          link.must_be_kind_of Link
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
- Added support for arrays of Links in the _links area, as defined in HAL standard (_links => { name => [{href => ''}, {href => ''}]})

For example, see the "admin" link from the HAL standard:

```
{
  "_links": {
    "self": { "href": "/orders" },
    ...,
    "admin": [
      { "href": "/admins/2", "title": "Fred" },
      { "href": "/admins/5", "title": "Kate" }
    ]
  },
  currentlyProcessing: 14,
  shippedToday: 20,
  "_embedded": {
   ...
  }
}
```
