### PR TITLE
Handle JSON that includes a link with a null value

### DIFF
--- a/lib/hyperclient/link_collection.rb
+++ b/lib/hyperclient/link_collection.rb
@@ -30,6 +30,7 @@ module Hyperclient
     #
     # Returns a Link or an array of Links when given an Array.
     def build_link(link_or_links, entry_point)
+      return unless link_or_links
       return Link.new(link_or_links, entry_point) unless link_or_links.respond_to?(:to_ary)
 
       link_or_links.collect do |link|

--- a/test/fixtures/element.json
+++ b/test/fixtures/element.json
@@ -14,7 +14,8 @@
             {
                 "href": "/gizmos/2"
             }
-        ]
+        ],
+        "null_link": null
     },
     "title": "Real World ASP.NET MVC3",
     "description": "In this advanced, somewhat-opinionated production you'll get your very own startup off the ground using ASP.NET MVC 3...",

--- a/test/hyperclient/link_collection_test.rb
+++ b/test/hyperclient/link_collection_test.rb
@@ -43,5 +43,12 @@ module Hyperclient
         end
       end
     end
+
+    describe "null link value" do
+      let(:null_link) { links.null_link }
+      it 'must be nil' do
+        null_link.must_be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
Previously, if the value of a link was `null`, Hyperclient would generate a Link object with nil href, etc. Subsequent access of Link#url and other methods had potential to raise NoMethodError as a result. Thus, it was unwieldy to check for null links via the Hyperclient API.

This PR changes Hyperclient's behavior: null links now result in nil values in the LinkCollection. Therefore, clients can check whether a link is nil, and thereby have good behavior when null links are present.

For example:

```
{
  ...,
  "_links" : {
    "optional" : null
  }
}
```

``` ruby
optional_link = api.links.optional
if optional_link
  ...
end
```
