### PR TITLE
Add Resource#rel, links and embeds are implementation details

### DIFF
--- a/lib/hyperclient/resource.rb
+++ b/lib/hyperclient/resource.rb
@@ -33,6 +33,13 @@ module Hyperclient
       @entry_point = entry_point
     end
 
+    # Public: Get a link or embed from the Resource
+    #
+    # name - The name of the link relation
+    def rel(name)
+      @embedded[name] || @links[name]
+    end
+
     def inspect
       "#<#{self.class.name} self_link:#{self_link.inspect} attributes:#{@attributes.inspect}>"
     end

--- a/test/hyperclient/resource_test.rb
+++ b/test/hyperclient/resource_test.rb
@@ -49,6 +49,25 @@ module Hyperclient
       end
     end
 
+    describe 'rel' do
+      let(:resource) { Resource.new({}, entry_point) }
+      let(:orders) { mock('Orders') }
+
+      it 'returns resource if relation is embedded' do
+        resource.embedded.expects(:[]).with(:orders).returns(orders)
+        resource.links.expects(:[]).never
+
+        resource.rel(:orders).must_equal orders
+      end
+
+      it 'returns link if relation is not embedded' do
+        resource.embedded.expects(:[]).returns(nil)
+        resource.links.expects(:[]).with(:orders).returns(orders)
+
+        resource.rel(:orders).must_equal orders
+      end
+    end
+
     it 'uses its self Link to handle HTTP connections' do
       self_link = mock('Self Link')
       self_link.expects(:get)


### PR DESCRIPTION
From what I understand of HAL and hypermedia, links and embeds are implementation details that the consumer should not know about. **relations** are what matter.

[section 8.3 of the HAL draft](http://tools.ietf.org/html/draft-kelly-json-hal-05#section-8.3):

> The "hypertext cache pattern" allows servers to use embedded resources to dynamically reduce the number of requests a client makes, improving the efficiency and performance of the application. Clients MAY be automated for this purpose so that, for any given link relation, they will read from an embedded resource (if present) in preference to traversing a link.
> 
> To activate this client behaviour for a given link, servers SHOULD add an embedded resource into the representation with the same relation.

So I propose that the following changes be made to Hyperclient.
- [x] Add a `#rel` method to `Resource` that first looks for an embedded resource and then a link.
- [ ] Add `#[]` and `#method_missing` on `Resource` that delegates to `#rel`
- [ ] Update all the docs to encourage the use `#rel` instead of `#links` and `#embedded`
