### PR TITLE
Expose link properties

### DIFF
--- a/lib/hyperclient/link.rb
+++ b/lib/hyperclient/link.rb
@@ -45,6 +45,36 @@ module Hyperclient
       @url ||= URITemplate.new(@link['href']).expand(@uri_variables)
     end
 
+    # Public: Returns the type property of the Link
+    def type
+      @link['type']
+    end
+
+    # Public: Returns the name property of the Link
+    def name
+      @link['name']
+    end
+
+    # Public: Returns the deprecation property of the Link
+    def deprecation
+      @link['deprecation']
+    end
+
+    # Public: Returns the profile property of the Link
+    def profile
+      @link['profile']
+    end
+
+    # Public: Returns the title property of the Link
+    def title
+      @link['title']
+    end
+
+    # Public: Returns the hreflang property of the Link
+    def hreflang
+      @link['hreflang']
+    end
+
     # Public: Returns the Resource which the Link is pointing to.
     def resource
       @resource ||=Resource.new(get.body, @entry_point)
@@ -92,9 +122,7 @@ module Hyperclient
     # This allows `api.links.posts.embedded` instead of
     # `api.links.posts.resource.embedded`
     def method_missing(method, *args, &block)
-      if @link.key?(method.to_s)
-        @link[method.to_s]
-      elsif resource.respond_to?(method)
+      if resource.respond_to?(method)
         resource.send(method, *args, &block)
       else
         super
@@ -104,7 +132,7 @@ module Hyperclient
     # Internal: Accessory method to allow the link respond to the
     # methods that will hit method_missing.
     def respond_to_missing?(method, include_private = false)
-      @link.key?(method.to_s) || resource.respond_to?(method.to_s)
+      resource.respond_to?(method.to_s)
     end
   end
 

--- a/test/hyperclient/link_test.rb
+++ b/test/hyperclient/link_test.rb
@@ -8,11 +8,16 @@ module Hyperclient
       EntryPoint.new('http://api.example.org/')
     end
 
-    %w(type deprecation name profile title hreflang).each do |attr|
-      describe attr do
-        it "returns the #{attr} attribute" do
-          link = Link.new({attr => 'value'}, entry_point)
-          link.send(attr).must_equal 'value'
+    %w(type deprecation name profile title hreflang).each do |prop|
+      describe prop do
+        it "returns the property value" do
+          link = Link.new({prop => 'value'}, entry_point)
+          link.send(prop).must_equal 'value'
+        end
+
+        it 'returns nil if the property is not present' do
+          link = Link.new({}, entry_point)
+          link.send(prop).must_equal nil
         end
       end
     end


### PR DESCRIPTION
HAL defines href, templated, type, deprecation, name, profile, title, and hreflang properties on links (http://tools.ietf.org/html/draft-kelly-json-hal-05#section-5). An implementation could also chose to implement their own, so this updates `#method_missing` to look for link properties before delegating to the resource.
