### PR TITLE
Fix for calling #flatten on an array of links

### DIFF
--- a/lib/hyperclient/link.rb
+++ b/lib/hyperclient/link.rb
@@ -104,6 +104,14 @@ module Hyperclient
     def respond_to_missing?(method, include_private = false)
       resource.respond_to?(method.to_s)
     end
+
+    # Internal: avoid delegating to resource
+    #
+    # #to_ary is called for implicit array coersion (such as parallel assignment
+    # or Array#flatten). Returning nil tells Ruby that this record is not Array-like.
+    def to_ary
+      nil
+    end
   end
 
   # Public: Exception that is raised when building a templated Link without uri

--- a/test/hyperclient/link_test.rb
+++ b/test/hyperclient/link_test.rb
@@ -149,13 +149,14 @@ module Hyperclient
       before do
         stub_request(:get, "http://myapi.org/orders").
           to_return(body: '{"resource": "This is the resource"}')
-        Resource.expects(:new).returns(resource).at_least_once
+        Resource.stubs(:new).returns(resource)
       end
 
       let(:link) { Link.new({'href' => 'http://myapi.org/orders'}, entry_point) }
       let(:resource) { mock('Resource') }
 
       it 'delegates unkown methods to the resource' do
+        Resource.expects(:new).returns(resource).at_least_once
         resource.expects(:embedded)
 
         link.embedded
@@ -168,6 +169,11 @@ module Hyperclient
       it 'responds to missing methods' do
         resource.expects(:respond_to?).with('embedded').returns(true)
         link.respond_to?(:embedded).must_equal true
+      end
+
+      it 'does not delegate to_ary to resource' do
+        resource.expects(:to_ary).never
+        [[link, link]].flatten.must_equal [link, link]
       end
     end
   end


### PR DESCRIPTION
Calling #flatten on an array of links will attempt to call #to_ary on `resource`. This fixes it by explicitly defining `Link#to_ary` to return `nil`. Here are related issues on other projects talking about this issue:

https://github.com/rspec/rspec-mocks/issues/31
https://github.com/bundler/bundler/pull/1274
