### PR TITLE
Default post/put/patch params

### DIFF
--- a/lib/hyperclient/link.rb
+++ b/lib/hyperclient/link.rb
@@ -100,15 +100,15 @@ module Hyperclient
       connection.delete(url)
     end
 
-    def post(params)
+    def post(params = {})
       connection.post(url, params)
     end
 
-    def put(params)
+    def put(params = {})
       connection.put(url, params)
     end
 
-    def patch(params)
+    def patch(params = {})
       connection.patch(url, params)
     end
 

--- a/test/hyperclient/link_test.rb
+++ b/test/hyperclient/link_test.rb
@@ -124,29 +124,44 @@ module Hyperclient
     end
 
     describe 'post' do
-      it 'sends a POST request with the link url and params' do
-        link = Link.new({'href' => '/productions/1'}, entry_point)
+      let(:link) { Link.new({'href' => '/productions/1'}, entry_point) }
 
+      it 'sends a POST request with the link url and params' do
         entry_point.connection.expects(:post).with('/productions/1', {'foo' => 'bar'})
         link.post({'foo' => 'bar'})
+      end
+
+      it 'defaults params to an empty hash' do
+        entry_point.connection.expects(:post).with('/productions/1', {})
+        link.post
       end
     end
 
     describe 'put' do
-      it 'sends a PUT request with the link url and params' do
-        link = Link.new({'href' => '/productions/1'}, entry_point)
+      let(:link) { Link.new({'href' => '/productions/1'}, entry_point) }
 
+      it 'sends a PUT request with the link url and params' do
         entry_point.connection.expects(:put).with('/productions/1', {'foo' => 'bar'})
         link.put({'foo' => 'bar'})
+      end
+
+      it 'defaults params to an empty hash' do
+        entry_point.connection.expects(:put).with('/productions/1', {})
+        link.put
       end
     end
 
     describe 'patch' do
-      it 'sends a PATCH request with the link url and params' do
-        link = Link.new({'href' => '/productions/1'}, entry_point)
+      let(:link) { Link.new({'href' => '/productions/1'}, entry_point) }
 
+      it 'sends a PATCH request with the link url and params' do
         entry_point.connection.expects(:patch).with('/productions/1', {'foo' => 'bar'})
         link.patch({'foo' => 'bar'})
+      end
+
+      it 'defaults params to an empty hash' do
+        entry_point.connection.expects(:patch).with('/productions/1', {})
+        link.patch
       end
     end
 


### PR DESCRIPTION
This changes `#post`, `#put` and `#patch` on `Link` to default the params to an empty hash. Some API endpoints don't require params.
