### PR TITLE
Help With Templated Links

### DIFF
--- a/lib/hyperclient/link.rb
+++ b/lib/hyperclient/link.rb
@@ -42,7 +42,14 @@ module Hyperclient
       return @link['href'] unless templated?
       raise MissingURITemplateVariablesException if @uri_variables == nil
 
-      @url ||= URITemplate.new(@link['href']).expand(@uri_variables)
+      @url ||= uri_template.expand(@uri_variables)
+    end
+
+    # Public: Returns an array of variables from the URITemplate.
+    #
+    # Returns an empty array for regular URIs.
+    def variables
+      uri_template.variables
     end
 
     # Public: Returns the type property of the Link
@@ -141,6 +148,11 @@ module Hyperclient
     # or Array#flatten). Returning nil tells Ruby that this record is not Array-like.
     def to_ary
       nil
+    end
+
+    # Internal: Memoization for a URITemplate instance
+    def uri_template
+      @uri_template ||= URITemplate.new(@link['href'])
     end
   end
 

--- a/test/hyperclient/link_test.rb
+++ b/test/hyperclient/link_test.rb
@@ -36,6 +36,20 @@ module Hyperclient
       end
     end
 
+    describe 'variables' do
+      it 'returns a list of required variables' do
+        link = Link.new({'href' => '/orders{?id,owner}', 'templated' => true}, entry_point)
+
+        link.variables.must_equal ['id', 'owner']
+      end
+
+      it 'returns an empty array for untemplated links' do
+        link = Link.new({'href' => '/orders'}, entry_point)
+
+        link.variables.must_equal []
+      end
+    end
+
     describe 'expand' do
       it 'buils a Link with the templated URI representation' do
         link = Link.new({'href' => '/orders{?id}', 'templated' => true}, entry_point)


### PR DESCRIPTION
So, if I have a link, and I know it's templated... There's not a way for me to use that information to actually build a query. In my case, I suspect that it takes some argument I'm interested in, but this being hypermedia, I should check before I just go ahead with things. What I'd like is a method that transparently proxies `URITemplate#variables` so that I can at least make sure the template still includes the thing I want to use.

If I put together a PR with this, does that sound like something worth merging?
