### PR TITLE
to_hash => to_h

### DIFF
--- a/lib/hyperclient/collection.rb
+++ b/lib/hyperclient/collection.rb
@@ -37,9 +37,10 @@ module Hyperclient
     # Public: Returns the wrapped collection as a hash.
     #
     # Returns a Hash.
-    def to_hash
+    def to_h
       @collection.to_hash
     end
+    alias_method :to_hash, :to_h
 
     def to_s
       to_hash


### PR DESCRIPTION
I think just an alias, at least for now, would be good, since this is the new convention for Ruby 2.0. Happy to do the work, if people are amenable.
