### PR TITLE
Hyperclient::LinkCollection#include? Broken?

### DIFF
--- a/lib/hyperclient/collection.rb
+++ b/lib/hyperclient/collection.rb
@@ -25,6 +25,10 @@ module Hyperclient
       @collection.each(&block)
     end
 
+    def include?(obj)
+      @collection.include?(obj)
+    end
+
     # Public: Provides Hash-like access to the collection.
     #
     # name - A String or Symbol of the value to get from the collection.

--- a/test/hyperclient/collection_test.rb
+++ b/test/hyperclient/collection_test.rb
@@ -40,6 +40,16 @@ module Hyperclient
         collection.to_hash.must_be_kind_of Hash
       end
     end
+
+    describe 'include?' do
+      it 'returns true for keys that exist' do
+        collection.include?('_links').must_equal true
+      end
+
+      it 'returns false for missing keys' do
+        collection.include?('missing key').must_equal false
+      end
+    end
   end
 end
 


### PR DESCRIPTION
Behold:

```
> resource.links.to_hash.keys
=> ["self", "profile"]
> resource.links.include?("profile")
=> false
```

I think this implies some weirdness in how `Enumerable` was pulled in? Anyway, it seems like something that would be useful in a hypermedia client: checking if a link you want to follow exists.

I'll dig into this some more and probably have a PR about it unless someone beats me to it. :smile: 
