### PR TITLE
uninitialized constant Hyperclient::Resource::Forwardable

### DIFF
--- a/lib/hyperclient/resource.rb
+++ b/lib/hyperclient/resource.rb
@@ -1,3 +1,4 @@
+require 'forwardable'
 require 'hyperclient/attributes'
 require 'hyperclient/link_collection'
 require 'hyperclient/resource_collection'


### PR DESCRIPTION
```
❱ ruby -e "require 'hyperclient'"
/home/ben/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/hyperclient-0.3.1/lib/hyperclient/resource.rb:9:in `<class:Resource>': uninitialized constant Hyperclient::Resource::Forwardable (NameError)
        from /home/ben/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/hyperclient-0.3.1/lib/hyperclient/resource.rb:8:in `<module:Hyperclient>'
        from /home/ben/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/hyperclient-0.3.1/lib/hyperclient/resource.rb:5:in `<top (required)>'
        from /home/ben/.rbenv/versions/2.0.0-p247/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:71:in `require'
        from /home/ben/.rbenv/versions/2.0.0-p247/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:71:in `require'
        from /home/ben/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/hyperclient-0.3.1/lib/hyperclient/link.rb:1:in `<top (required)>'
        from /home/ben/.rbenv/versions/2.0.0-p247/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:71:in `require'
        from /home/ben/.rbenv/versions/2.0.0-p247/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:71:in `require'
        from /home/ben/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/hyperclient-0.3.1/lib/hyperclient/entry_point.rb:1:in `<top (required)>'
        from /home/ben/.rbenv/versions/2.0.0-p247/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:71:in `require'
        from /home/ben/.rbenv/versions/2.0.0-p247/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:71:in `require'
        from /home/ben/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/hyperclient-0.3.1/lib/hyperclient.rb:1:in `<top (required)>'
        from /home/ben/.rbenv/versions/2.0.0-p247/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:133:in `require'
        from /home/ben/.rbenv/versions/2.0.0-p247/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:133:in `rescue in require'
        from /home/ben/.rbenv/versions/2.0.0-p247/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:142:in `require'
        from -e:1:in `<main>'
```

I think there's a missing `require 'forwardable'` somewhere in the codebase. Concur? If so, I'll hunt it down and make a Pull Request.
