### PR TITLE
Fixed a bug which was allowing the response.body to be mutated

### DIFF
--- a/lib/hyperclient/resource.rb
+++ b/lib/hyperclient/resource.rb
@@ -32,7 +32,7 @@ module Hyperclient
     # representation - The hash with the HAL representation of the Resource.
     # entry_point    - The EntryPoint object to inject the configutation.
     def initialize(representation, entry_point, response=nil)
-      representation ||= {}
+      representation = representation ? representation.dup : {}
       @links       = LinkCollection.new(representation['_links'], entry_point)
       @embedded    = ResourceCollection.new(representation['_embedded'], entry_point)
       @attributes  = Attributes.new(representation)

--- a/test/hyperclient/resource_test.rb
+++ b/test/hyperclient/resource_test.rb
@@ -31,6 +31,16 @@ module Hyperclient
 
         resource.response.must_equal mock_response
       end
+
+      it "does not mutate the response.body" do
+        body = { 'foo' => 'bar', '_links' => {}, '_embedded' => {} }
+        mock_response = stub(body: body.dup)
+
+        resource = Resource.new(mock_response.body, entry_point, mock_response)
+
+        resource.response.body.must_equal body
+      end
+
     end
 
     describe 'accessors' do


### PR DESCRIPTION
This pull request resolves [this issue](https://github.com/codegram/hyperclient/issues/49).
