### PR TITLE
Added an ability to override the default Faraday block

### DIFF
--- a/lib/hyperclient.rb
+++ b/lib/hyperclient.rb
@@ -9,7 +9,7 @@ module Hyperclient
   # url - A String with the url of the API.
   #
   # Returns a Hyperclient::EntryPoint
-  def self.new(url)
-    Hyperclient::EntryPoint.new(url)
+  def self.new(url, &block)
+    Hyperclient::EntryPoint.new(url, &block)
   end
 end

--- a/lib/hyperclient/entry_point.rb
+++ b/lib/hyperclient/entry_point.rb
@@ -18,16 +18,18 @@ module Hyperclient
     # Public: Initializes an EntryPoint.
     #
     # url    - A String with the entry point of your API.
-    def initialize(url)
+    def initialize(url, &block)
       @link = {'href' => url}
       @entry_point = self
+      @faraday_block = block if block_given?
     end
 
     # Public: A Faraday connection to use as a HTTP client.
     #
     # Returns a Faraday::Connection.
     def connection
-      @connection ||= Faraday.new(url, {headers: default_headers}, &default_faraday_block)
+      block = @faraday_block || default_faraday_block
+      @connection ||= Faraday.new(url, {headers: default_headers}, &block)
     end
 
     private

--- a/test/hyperclient/entry_point_test.rb
+++ b/test/hyperclient/entry_point_test.rb
@@ -23,6 +23,21 @@ module Hyperclient
         handlers.must_include FaradayMiddleware::ParseJson
         handlers.must_include Faraday::Adapter::NetHttp
       end
+
+      describe 'when initialized with a custom block' do
+        let(:entry_point) do
+          EntryPoint.new('http://my.api.org') do |connection|
+            connection.use FaradayMiddleware::FollowRedirects
+            connection.adapter :net_http
+          end
+        end
+
+        it 'creates a Faraday connection with that block' do
+          handlers = entry_point.connection.builder.handlers
+          handlers.must_include Faraday::Adapter::NetHttp
+          handlers.must_include FaradayMiddleware::FollowRedirects
+        end
+      end
     end
 
     describe 'initialize' do


### PR DESCRIPTION
Allowing to initialise hyperclient with a Faraday block, to allow proper Faraday initialisation. Changes are pretty basic. 
Looks like the same problem as discussed in https://github.com/codegram/hyperclient/issues/51
