### PR TITLE
Test Link#expand raises ArgumentError with no args

### DIFF
--- a/test/hyperclient/link_test.rb
+++ b/test/hyperclient/link_test.rb
@@ -60,8 +60,7 @@ module Hyperclient
 
       it 'raises if no uri variables are given' do
         link = Link.new({'href' => '/orders{?id}', 'templated' => true}, entry_point)
-
-        proc { link.resource.url }.must_raise MissingURITemplateVariablesException
+        lambda { link.expand }.must_raise ArgumentError
       end
     end
 


### PR DESCRIPTION
Just aiming to make the build green, the fix is quite trivial. Unless I'm missing something, Link#expand would raise ArgumentError when passing no arguments. If that would be the case, maybe this test can be scraped altogether?

The original test code was trying link.resource.url, I changed it to reflect the description of the test.
