### PR TITLE
Fix readme merge example

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,7 +16,7 @@ Example API client:
 ```ruby
 api = Hyperclient.new('http://myapp.com/api').tap do |api|
   api.digest_auth('user', 'password')
-  api.headers.merge({'accept-encoding' => 'deflate, gzip'})
+  api.headers.update({'accept-encoding' => 'deflate, gzip'})
 end
 ```
 


### PR DESCRIPTION
The `headers.merge()` example in the readme didn't work because it was creating a new hash instead of updating the hash in place.

Using `headers.update` solves it.
