### PR TITLE
Added support for setting headers and overriding or extending the default Faraday connection block before a connection is constructed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 This version introduces several backwards incompatible changes. See [UPGRADING](UPGRADING.md) for details.
 
-* [#41](https://github.com/codegram/hyperclient/issues/41): All Link HTTP methods now return a Resource, including `_get`, which has been aliased to `_resource`, `_post`, `_put`, `_patch`, `_head` and `_options` - [@dblock](https://github.com/dblock).
+* [#51](https://github.com/codegram/hyperclient/issues/51), [#75](https://github.com/codegram/hyperclient/pull/75): Added support for setting headers and overriding or extending the default Faraday connection block before a connection is constructed - [@dblock](https://github.com/dblock).
+* [#41](https://github.com/codegram/hyperclient/issues/41), [#73](https://github.com/codegram/hyperclient/pull/73): All Link HTTP methods now return a Resource, including `_get`, which has been aliased to `_resource`, `_post`, `_put`, `_patch`, `_head` and `_options` - [@dblock](https://github.com/dblock).
 * [#72](https://github.com/codegram/hyperclient/pull/72): The default Faraday block now uses `Faraday::Response::RaiseError` and will cause HTTP errors to be raised as exceptions - [@dblock](https://github.com/dblock).
 * Your contribution here.
 

--- a/lib/hyperclient.rb
+++ b/lib/hyperclient.rb
@@ -9,7 +9,7 @@ module Hyperclient
   # url - A String with the url of the API.
   #
   # Returns a Hyperclient::EntryPoint
-  def self.new(url)
-    Hyperclient::EntryPoint.new(url)
+  def self.new(url, &block)
+    Hyperclient::EntryPoint.new(url, &block)
   end
 end

--- a/test/hyperclient_test.rb
+++ b/test/hyperclient_test.rb
@@ -8,5 +8,36 @@ describe Hyperclient do
 
       Hyperclient.new('http://api.example.org')
     end
+
+    describe 'with an optional block' do
+      let(:client) do
+        Hyperclient.new('http://api.example.org') do |client|
+          client.connection(default: true) do |conn|
+            conn.use Faraday::Request::OAuth
+          end
+          client.headers['Access-Token'] = 'token'
+        end
+      end
+
+      it 'creates a Faraday connection with the default and additional headers' do
+        client.headers['Content-Type'].must_equal 'application/json'
+        client.headers['Accept'].must_equal 'application/json'
+        client.headers['Access-Token'].must_equal 'token'
+      end
+
+      it 'creates a Faraday connection with the entry point url' do
+        client.connection.url_prefix.to_s.must_equal 'http://api.example.org/'
+      end
+
+      it 'creates a Faraday connection with the default block plus any additional handlers' do
+        handlers = client.connection.builder.handlers
+        handlers.must_include Faraday::Request::OAuth
+        handlers.must_include Faraday::Response::RaiseError
+        handlers.must_include FaradayMiddleware::FollowRedirects
+        handlers.must_include FaradayMiddleware::EncodeJson
+        handlers.must_include FaradayMiddleware::ParseJson
+        handlers.must_include Faraday::Adapter::NetHttp
+      end
+    end
   end
 end


### PR DESCRIPTION
From the updated README:

By default, Hyperclient adds `application/json` as `Content-Type` and `Accept` headers. It will also send requests as JSON and parse JSON responses. Specify additional headers or authentication if necessary.

``` ruby
api = Hyperclient.new('https://grape-with-roar.herokuapp.com/api') do |client|
  client.headers['Access-Token'] = 'token' # this is new, you can access headers before the connection is built
end
```

By default, Hyperclient constructs a connection using typical [Faraday](http://github.com/lostisland/faraday) middleware for handling JSON requests and responses. You can specify additional Faraday middleware if necessary.

``` ruby
api = Hyperclient.new('https://grape-with-roar.herokuapp.com/api') do |client|
  client.connection do |conn|
    conn.use Faraday::Request::OAuth # this is new, you can add middleware to the default Faraday connection block
  end
end
```

You can build a new Faraday connection block without inheriting default middleware by specifying `default: false` in the `connection` block.

``` ruby
api = Hyperclient.new('https://grape-with-roar.herokuapp.com/api') do |client|
  # this is new, you can just say default: false and not inherit anything, this also lets us specify other options in the future
  client.connection(default: false) do |conn|
    conn.request :json
    conn.response :json, content_type: /\bjson$/
    conn.adapter :net_http
  end
end
```

You can modify headers or specify authentication after a connection has been created. Hyperclient supports Basic, Token or Digest auth as well as many other [Faraday](http://github.com/lostisland/faraday) extensions.

``` ruby
api = Hyperclient.new('https://grape-with-roar.herokuapp.com/api')
api.digest_auth('username', 'password')
api.headers.update('Accept-Encoding' => 'deflate, gzip')
```

You can access the Faraday connection directly after it has been created and add middleware to itpoint. As an example, you could use the [faraday-http-cache-middleware](https://github.com/plataformatec/faraday-http-cache).

``` ruby
api = Hyperclient.new('https://grape-with-roar.herokuapp.com/api')
api.connection.use :http_cache
```
