### PR TITLE
Added support for templated links with no arguments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This version introduces several backwards incompatible changes. See [UPGRADING](
 * [#51](https://github.com/codegram/hyperclient/issues/51), [#75](https://github.com/codegram/hyperclient/pull/75): Added support for setting headers and overriding or extending the default Faraday connection block before a connection is constructed - [@dblock](https://github.com/dblock).
 * [#41](https://github.com/codegram/hyperclient/issues/41), [#73](https://github.com/codegram/hyperclient/pull/73): All Link HTTP methods now return a Resource, including `_get`, which has been aliased to `_resource`, `_post`, `_put`, `_patch`, `_head` and `_options` - [@dblock](https://github.com/dblock).
 * [#72](https://github.com/codegram/hyperclient/pull/72): The default Faraday block now uses `Faraday::Response::RaiseError` and will cause HTTP errors to be raised as exceptions - [@dblock](https://github.com/dblock).
+* [#77](https://github.com/codegram/hyperclient/pull/77): Added support for templated links with all optional arguments - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 ### 0.5.0 (October 1, 2014)

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ puts "Spline #{spline.uuid} is #{spline.reticulated ? 'reticulated' : 'not retic
 
 Invoking `api.spline(uuid: 'uuid').reticulated` is equivalent to `api._links.spline._expand(uuid: 'uuid')._resource._attributes.reticulated`.
 
+The client is responsible for supplying all the necessary parameters. Templated links don't do any strict parameter name checking and don't support required vs. optional parameters. Parameters not declared by the API will be dropped and will not have any effect when passed to `_expand`.
+
 ### Curies
 
 Curies are named tokens that you can define in the document and use to express curie relation URIs in a friendlier, more compact fashion. For example, the demo API contains very long links to images that use an "images" curie. Hyperclient handles curies and resolves these into full links automatically.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -11,6 +11,10 @@ The default Faraday block now uses `Faraday::Response::RaiseError` and will caus
 
 The `Link#_get` method has been aliased to `_resource`. All HTTP methods, including `_post`, `_put`, `_delete`, `_patch`, `_options` and `_head` now return instances of Resource. Older versions returned a `Faraday::Response`.
 
+#### Changes in URI Template Expansion
+
+A `MissingURITemplateVariablesException` exception will no longer be raised when expanding a link with no arguments. The `Link#_expand` method will now also accept zero arguments and default the variables to `{}`. This enables support for templated links with all optional arguments.
+
 ### Upgrading to >= 0.5.0
 
 #### Remove Navigational Elements

--- a/lib/hyperclient/link.rb
+++ b/lib/hyperclient/link.rb
@@ -33,19 +33,14 @@ module Hyperclient
     # uri_variables - The Hash with the variables to expand the URITemplate.
     #
     # Returns a new Link with the expanded variables.
-    def _expand(uri_variables)
+    def _expand(uri_variables = {})
       self.class.new(@key, @link, @entry_point, uri_variables)
     end
 
     # Public: Returns the url of the Link.
-    #
-    # Raises MissingURITemplateVariables if the Link is templated but there are
-    # no uri variables to expand it.
     def _url
       return @link['href'] unless _templated?
-      fail MissingURITemplateVariablesException if @uri_variables.nil?
-
-      @url ||= _uri_template.expand(@uri_variables)
+      @url ||= _uri_template.expand(@uri_variables || {})
     end
 
     # Public: Returns an array of variables from the URITemplate.
@@ -200,15 +195,6 @@ module Hyperclient
     # Internal: Memoization for a URITemplate instance
     def _uri_template
       @uri_template ||= URITemplate.new(@link['href'])
-    end
-  end
-
-  # Public: Exception that is raised when building a templated Link without uri
-  # variables.
-  class MissingURITemplateVariablesException < StandardError
-    # Public: Returns a String with the exception message.
-    def message
-      'The URL to this links is templated, but no variables where given.'
     end
   end
 end

--- a/test/hyperclient/link_test.rb
+++ b/test/hyperclient/link_test.rb
@@ -51,24 +51,38 @@ module Hyperclient
     end
 
     describe '_expand' do
-      it 'buils a Link with the templated URI representation' do
-        link = Link.new('key', { 'href' => '/orders{?id}', 'templated' => true }, entry_point)
+      describe 'required argument' do
+        it 'builds a Link with the templated URI representation' do
+          link = Link.new('key', { 'href' => '/orders/{id}', 'templated' => true }, entry_point)
+          link._expand(id: '1')._url.must_equal '/orders/1'
+        end
 
-        Link.expects(:new).with('key', anything, entry_point, id: '1')
-        link._expand(id: '1')
+        it 'expands an uri template without variables' do
+          link = Link.new('key', { 'href' => '/orders/{id}', 'templated' => true }, entry_point)
+          link._expand._url.must_equal '/orders/'
+          link._url.must_equal '/orders/'
+        end
       end
 
-      it 'raises if no uri variables are given' do
-        link = Link.new('key', { 'href' => '/orders{?id}', 'templated' => true }, entry_point)
-        lambda { link._expand }.must_raise ArgumentError
+      describe 'query string argument' do
+        it 'builds a Link with the templated URI representation' do
+          link = Link.new('key', { 'href' => '/orders{?id}', 'templated' => true }, entry_point)
+          link._expand(id: '1')._url.must_equal '/orders?id=1'
+        end
+
+        it 'expands an uri template without variables' do
+          link = Link.new('key', { 'href' => '/orders{?id}', 'templated' => true }, entry_point)
+          link._expand._url.must_equal '/orders'
+          link._url.must_equal '/orders'
+        end
       end
     end
 
     describe '_url' do
-      it 'raises when missing required uri_variables' do
+      it 'expands an uri template without variables' do
         link = Link.new('key', { 'href' => '/orders{?id}', 'templated' => true }, entry_point)
 
-        lambda { link._url }.must_raise MissingURITemplateVariablesException
+        link._url.must_equal '/orders'
       end
 
       it 'expands an uri template with variables' do


### PR DESCRIPTION
HAL API spec don't describe what's required vs. what's not in a URI parameter. These are just URI templates per https://tools.ietf.org/html/rfc6570. 

It seems incorrect to raise a `MissingURITemplateVariablesException` for a templated link because you can have something like this: `/orders{?page,size}`. Now of course we could say any `{parameter}` is required and any `{?parameter}` is optional, but that wouldn't match the URI template RFC either.

This change relaxes the requirement to specify parameters to expand a templated link, with an additional warning in the README.
