### PR TITLE
Cleanup

### DIFF
--- a/lib/hyperclient/collection.rb
+++ b/lib/hyperclient/collection.rb
@@ -1,5 +1,5 @@
 module Hyperclient
-  # Public: A helper class to wrapp a collection of elements and provide
+  # Public: A helper class to wrap a collection of elements and provide
   # Hash-like access or via a method call.
   #
   # Examples
@@ -25,8 +25,13 @@ module Hyperclient
       @collection.each(&block)
     end
 
-    def include?(obj)
-      @collection.include?(obj)
+    # Public: Checks if this collection includes a given key.
+    #
+    # key - A String or Symbol to check for existance.
+    #
+    # Returns True/False.
+    def include?(key)
+      @collection.include?(key)
     end
 
     # Public: Returns a value from the collection for the given key.
@@ -51,7 +56,7 @@ module Hyperclient
       @collection[name.to_s]
     end
 
-    # Public: Returns the wrapped collection as a hash.
+    # Public: Returns the wrapped collection as a Hash.
     #
     # Returns a Hash.
     def to_h

--- a/lib/hyperclient/curie.rb
+++ b/lib/hyperclient/curie.rb
@@ -7,8 +7,8 @@ module Hyperclient
   class Curie
     # Public: Initializes a new Curie.
     #
-    # curie          - The String with the URI of the curie.
-    # entry_point   - The EntryPoint object to inject the cofnigutation.
+    # curie_hash  - The String with the URI of the curie.
+    # entry_point - The EntryPoint object to inject the configuration.
     def initialize(curie_hash, entry_point)
       @curie_hash = curie_hash
       @entry_point = entry_point
@@ -22,12 +22,12 @@ module Hyperclient
       !!@curie_hash['templated']
     end
 
-    # Public: Returns the name property of the Curie
+    # Public: Returns the name property of the Curie.
     def name
       @curie_hash['name']
     end
 
-    # Public: Returns the href property of the Curie
+    # Public: Returns the href property of the Curie.
     def href
       @curie_hash['href']
     end
@@ -38,7 +38,7 @@ module Hyperclient
 
     # Public: Expands the Curie when is templated with the given variables.
     #
-    # rel - The rel to expand.
+    # rel - The String rel to expand.
     #
     # Returns a new expanded url.
     def expand(rel)

--- a/lib/hyperclient/entry_point.rb
+++ b/lib/hyperclient/entry_point.rb
@@ -43,9 +43,9 @@ module Hyperclient
 
     # Public: A Faraday connection to use as a HTTP client.
     #
-    # options    - A Hash containing additional options.
-    #
-    #  default   - Set to true to reuse default Faraday connection options.
+    # options - A Hash containing additional options to pass to Farday. Use
+    # {default: false} if you want to skip using default Faraday options set by
+    # Hyperclient.
     #
     # Returns a Faraday::Connection.
     def connection(options = {}, &block)
@@ -123,12 +123,12 @@ module Hyperclient
     #
     # Returns a block.
     def default_faraday_block
-      lambda do |conn|
-        conn.use Faraday::Response::RaiseError
-        conn.use FaradayMiddleware::FollowRedirects
-        conn.request :hal_json
-        conn.response :hal_json, content_type: /\bjson$/
-        conn.adapter :net_http
+      lambda do |connection|
+        connection.use Faraday::Response::RaiseError
+        connection.use FaradayMiddleware::FollowRedirects
+        connection.request :hal_json
+        connection.response :hal_json, content_type: /\bjson$/
+        connection.adapter :net_http
       end
     end
 

--- a/lib/hyperclient/link.rb
+++ b/lib/hyperclient/link.rb
@@ -80,76 +80,37 @@ module Hyperclient
       @link['hreflang']
     end
 
-    # Public: Returns the Resource which the Link is pointing to.
-    def _get
-      @resource = begin
-        response = Futuroscope::Future.new do
-          _connection.get(_url)
-        end
-        Resource.new(response.body, @entry_point, response)
-      end
-    end
-
     def _resource
       @resource || _get
     end
 
-    def _connection
-      @entry_point.connection
+    # Public: Returns the Resource which the Link is pointing to.
+    def _get
+      http_method(:get)
     end
 
     def _options
-      @resource = begin
-        response = Futuroscope::Future.new do
-          _connection.run_request(:options, _url, nil, nil)
-        end
-        Resource.new(response.body, @entry_point, response)
-      end
+      http_method(:options)
     end
 
     def _head
-      @resource = begin
-        response = Futuroscope::Future.new do
-          _connection.head(_url)
-        end
-        Resource.new(response.body, @entry_point, response)
-      end
+      http_method(:head)
     end
 
     def _delete
-      @resource = begin
-        response = Futuroscope::Future.new do
-          _connection.delete(_url)
-        end
-        Resource.new(response.body, @entry_point, response)
-      end
+      http_method(:delete)
     end
 
     def _post(params = {})
-      @resource = begin
-        response = Futuroscope::Future.new do
-          _connection.post(_url, params)
-        end
-        Resource.new(response.body, @entry_point, response)
-      end
+      http_method(:post, params)
     end
 
     def _put(params = {})
-      @resource = begin
-        response = Futuroscope::Future.new do
-          _connection.put(_url, params)
-        end
-        Resource.new(response.body, @entry_point, response)
-      end
+      http_method(:put, params)
     end
 
     def _patch(params = {})
-      @resource = begin
-        response = Futuroscope::Future.new do
-          _connection.patch(_url, params)
-        end
-        Resource.new(response.body, @entry_point, response)
-      end
+      http_method(:patch, params)
     end
 
     def inspect
@@ -197,6 +158,15 @@ module Hyperclient
     # Internal: Memoization for a URITemplate instance
     def _uri_template
       @uri_template ||= URITemplate.new(@link['href'])
+    end
+
+    def http_method(method, body = nil)
+      @resource = begin
+        response = Futuroscope::Future.new do
+          @entry_point.connection.run_request(method, _url, body, nil)
+        end
+        Resource.new(response.body, @entry_point, response)
+      end
     end
   end
 end

--- a/lib/hyperclient/link.rb
+++ b/lib/hyperclient/link.rb
@@ -10,7 +10,7 @@ module Hyperclient
     #
     # key           - The key or name of the link.
     # link          - The String with the URI of the link.
-    # entry_point   - The EntryPoint object to inject the cofnigutation.
+    # entry_point   - The EntryPoint object to inject the configuration.
     # uri_variables - The optional Hash with the variables to expand the link
     #                 if it is templated.
     def initialize(key, link, entry_point, uri_variables = nil)

--- a/lib/hyperclient/link_collection.rb
+++ b/lib/hyperclient/link_collection.rb
@@ -13,8 +13,8 @@ module Hyperclient
   class LinkCollection < Collection
     # Public: Initializes a LinkCollection.
     #
-    # collection - The Hash with the links.
-    # curies - Link curies.
+    # collection  - The Hash with the links.
+    # curies      - The Hash with link curies.
     # entry_point - The EntryPoint object to inject the configuration.
     def initialize(collection, curies, entry_point)
       fail "Invalid response for LinkCollection. The response was: #{collection.inspect}" if collection && !collection.respond_to?(:collect)
@@ -33,13 +33,15 @@ module Hyperclient
 
     # Internal: Creates links from the response hash.
     #
+    # name          - A String to identify the link's name.
     # link_or_links - A Hash or an Array of hashes with the links to build.
-    # entry_point - The EntryPoint object to inject the configuration.
-    # curies - Optional curies for templated links.
+    # curies        - An Array of Curies for templated links.
+    # entry_point   - The EntryPoint object to inject the configuration.
     #
-    # Returns a Link or an array of Links when given an Array.
+    # Returns a Link or an Array of Links when given an Array.
     def build_link(name, link_or_links, curies, entry_point)
       return unless link_or_links
+
       if link_or_links.respond_to?(:to_ary)
         link_or_links.map do |link|
           build_link(name, link, curies, entry_point)

--- a/lib/hyperclient/resource_collection.rb
+++ b/lib/hyperclient/resource_collection.rb
@@ -14,7 +14,7 @@ module Hyperclient
     # Public: Initializes a ResourceCollection.
     #
     # collection  - The Hash with the embedded resources.
-    # entry_point - The EntryPoint object to inject the cofnigutation.
+    # entry_point - The EntryPoint object to inject the configuration.
     #
     def initialize(collection, entry_point)
       @entry_point = entry_point

--- a/test/hyperclient/link_test.rb
+++ b/test/hyperclient/link_test.rb
@@ -117,12 +117,6 @@ module Hyperclient
       end
     end
 
-    describe '_connection' do
-      it 'returns the entry point connection' do
-        Link.new('key', {}, entry_point)._connection.must_equal entry_point.connection
-      end
-    end
-
     describe 'get' do
       it 'sends a GET request with the link url' do
         link = Link.new('key', { 'href' => '/productions/1' }, entry_point)


### PR DESCRIPTION
Just some documentation and style fixes, and reduced the duplication when defining HTTP methods at `Link`