### PR TITLE
[Do not merge] Added feature test on page navigation which fails.

### DIFF
--- a/features/api_navigation.feature
+++ b/features/api_navigation.feature
@@ -21,3 +21,7 @@ Feature: API navigation
     Given I connect to the API
     When I load a single post
     Then I should also be able to access it's embedded comments
+
+  Scenario: Navigation links
+    When I connect to the API
+    Then I should be able to navigate to next page

--- a/features/steps/api_navigation.rb
+++ b/features/steps/api_navigation.rb
@@ -30,4 +30,9 @@ class Spinach::Features::ApiNavigation < Spinach::FeatureSteps
     comment = @post._embedded.comments.first
     comment._attributes.title.wont_equal nil
   end
+
+  step 'I should be able to navigate to next page' do
+    # This should go to page2, but it goes to page3
+    assert_equal '/posts_of_page2', api._links.next._links.posts._url
+  end
 end

--- a/features/support/api.rb
+++ b/features/support/api.rb
@@ -8,6 +8,8 @@ module API
     stub_request(:any, %r{api.example.org*}).to_return(body: root_response, headers: { 'Content-Type' => 'application/hal+json' })
     stub_request(:get, 'api.example.org/posts').to_return(body: posts_response, headers: { 'Content-Type' => 'application/hal+json' })
     stub_request(:get, 'api.example.org/posts/1').to_return(body: post_response, headers: { 'Content-Type' => 'application/hal+json' })
+    stub_request(:get, 'api.example.org/page2').to_return(body: page2_response, headers: { 'Content-Type' => 'application/hal+json' })
+    stub_request(:get, 'api.example.org/page3').to_return(body: page3_response, headers: { 'Content-Type' => 'application/hal+json' })
   end
 
   def api

--- a/features/support/fixtures.rb
+++ b/features/support/fixtures.rb
@@ -8,7 +8,8 @@ module Spinach
               "self": { "href": "/" },
               "posts": { "href": "/posts" },
               "search": { "href": "/search{?q}", "templated": true },
-              "api:authors": { "href": "/authors" }
+              "api:authors": { "href": "/authors" },
+              "next": { "href": "/page2" }
           }
       }'
     end
@@ -36,6 +37,26 @@ module Spinach
                 "title": "Some comment"
               }
             ]
+          }
+      }'
+    end
+
+    def page2_response
+      '{
+          "_links": {
+              "self": { "href": "/page2" },
+              "posts": { "href": "/posts_of_page2" },
+              "next": { "href": "/page3" }
+          }
+      }'
+    end
+
+    def page3_response
+      '{
+          "_links": {
+              "self": { "href": "/page3" },
+              "posts": { "href": "/posts_of_page3" },
+              "api:authors": { "href": "/authors" }
           }
       }'
     end


### PR DESCRIPTION
Hey guys. I am using HyperClient in my project to consume HAL service. The HAL service provides links for navigation. (e.g. self page, next page).

I found one issue that when you call `_links.next` on the HyperClient api/link, it is not justing going to next page but is navigating recursively until it is hitting the last page.

Not sure it is an issue or it is just I am using it wrong.

Check the file changes in this commit about the failing test.

Thanks.