### PR TITLE
Use protocol relative URI to load documentup

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title></title>
-    <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/documentup/latest.min.js"></script>
+    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/documentup/latest.min.js"></script>
     <script type="text/javascript">
       DocumentUp.document({
         repo:  "codegram/hyperclient",


### PR DESCRIPTION
Visiting https://codegram.github.io/hyperclient/ with a modern browser (Chrome e.g.) will display an empty side, because documentup is loaded via HTTP.

> Mixed Content: The page at 'https://codegram.github.io/hyperclient/' was loaded over HTTPS, but requested an insecure script 'http://cdnjs.cloudflare.com/ajax/libs/documentup/latest.min.js'. This request has been blocked; the content must be served over HTTPS.