### PR TITLE
Add method fetch for Hyperclient::Resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.7.1 (Next)
 
 * [#87](https://github.com/codegram/hyperclient/pull/87): Fix: eager delegation causes link skipping - [@dblock](https://github.com/dblock).
+* [#89](https://github.com/codegram/hyperclient/issues/89): Add method fetch for Hyperclient::Resource - [@alabeduarte](https://github.com/alabeduarte).
 * Your contribution here.
 
 ### 0.7.0 (February 23, 2015)

--- a/README.md
+++ b/README.md
@@ -95,6 +95,15 @@ api.splines.each do |spline|
 end
 ```
 
+Other methods, including `[]` and `fetch` are also available
+
+```ruby
+api.splines.each do |spline|
+  puts "A spline with ID #{spline[:uuid]}."
+  puts "Maybe with reticulated: #{spline.fetch(:reticulated, '-- no reticulated')}"
+end
+```
+
 ### Links and Embedded Resources
 
 The splines example above followed a link called "splines". While you can, you do not need to specify the HAL navigational structure, including links or embedded resources. Hyperclient will resolve these for you.  If you prefer, you can explicitly navigate the link structure via `_links`. In the following example the "splines" link leads to a collection of embedded splines. Invoking `api.splines` is equivalent to `api._links.splines._embedded.splines`.

--- a/lib/hyperclient/resource.rb
+++ b/lib/hyperclient/resource.rb
@@ -57,6 +57,18 @@ module Hyperclient
       send(name) if respond_to?(name)
     end
 
+    def fetch(key, *args)
+      return self[key] if respond_to?(key)
+
+      if args.any?
+        args.first
+      elsif block_given?
+        yield key
+      else
+        fail KeyError
+      end
+    end
+
     private
 
     # Internal: Returns the self Link of the Resource. Used to handle the HTTP

--- a/test/hyperclient/resource_test.rb
+++ b/test/hyperclient/resource_test.rb
@@ -101,6 +101,44 @@ module Hyperclient
           resource._attributes.expects(:foo).returns('bar')
           resource['foo'].must_equal 'bar'
         end
+
+        describe '#fetch' do
+          it 'returns the value for keys that exist' do
+            resource._attributes.expects(:foo).returns('bar')
+
+            resource.fetch('foo').must_equal 'bar'
+          end
+
+          it 'raises an error for missing keys' do
+            proc { resource.fetch('missing key') }.must_raise KeyError
+          end
+
+          describe 'with a default value' do
+            it 'returns the value for keys that exist' do
+              resource._attributes.expects(:foo).returns('bar')
+              resource.fetch('foo', 'default value').must_equal 'bar'
+            end
+
+            it 'returns the default value for missing keys' do
+              resource.fetch('missing key', 'default value').must_equal 'default value'
+            end
+          end
+
+          describe 'with a block' do
+            it 'returns the value for keys that exist' do
+              resource._attributes.expects(:foo).returns('bar')
+              resource.fetch('foo') { 'default value' }.must_equal 'bar'
+            end
+
+            it 'returns the value from the block' do
+              resource.fetch('z') { 'go fish!' }.must_equal 'go fish!'
+            end
+
+            it 'returns the value with args from the block' do
+              resource.fetch('z') { |el| "go fish, #{el}" }.must_equal 'go fish, z'
+            end
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Hi all,

Sometimes I use the [Hyperclient::Resource#[]](https://github.com/codegram/hyperclient/blob/master/lib/hyperclient/resource.rb#L56) as a hash, but I would like to avoid if statements when the attribute does not exist for some reason.

I hope this idea fit to the gem purposes

Thanks!