### PR TITLE
curies: don't expand when the rel is already absolute (starts with http[s]:)

### DIFF
--- a/lib/hyperclient/curie.rb
+++ b/lib/hyperclient/curie.rb
@@ -40,8 +40,9 @@ module Hyperclient
     #
     # rel - The String rel to expand.
     #
-    # Returns a new expanded url.
+    # Returns a new expanded url unless the url already starts with http[s]:
     def expand(rel)
+      return rel if /^http[s]?:/i.match(rel)
       return rel unless rel && templated?
       href.gsub('{rel}', rel) if href
     end


### PR DESCRIPTION
If a rel is already absolute then don't try to help by expanding it.  
This change allows folks who are using curies the way hal-browser expects (for doc links) to coexist with hyperclient.
See issue #97 