### PR TITLE
Discussion: Custom query params

### DIFF
--- a/lib/hyperclient/curie.rb
+++ b/lib/hyperclient/curie.rb
@@ -40,8 +40,9 @@ module Hyperclient
     #
     # rel - The String rel to expand.
     #
-    # Returns a new expanded url.
+    # Returns a new expanded url unless the url already starts with http[s]:
     def expand(rel)
+      return rel if /^http[s]?:/i.match(rel)
       return rel unless rel && templated?
       href.gsub('{rel}', rel) if href
     end


### PR DESCRIPTION
This is just for discussion, merge not requested.  Re issue #97 

Allow the caller to set custom query parameters when fetching a link
````
events_link=api._links['events']
events_link.query_params= { filter: "modified_date gt '2016-01-01'" }
events=events_link['items']
````
