### PR TITLE
Don't use curies to expand resource links. Curies hrefs are for doc links

### DIFF
--- a/lib/hyperclient/link_collection.rb
+++ b/lib/hyperclient/link_collection.rb
@@ -46,10 +46,6 @@ module Hyperclient
         link_or_links.map do |link|
           build_link(name, link, curies, entry_point)
         end
-      elsif (curie_parts = /(?<ns>[^:]+):(?<short_name>.+)/.match(name))
-        curie = curies[curie_parts[:ns]]
-        link_or_links['href'] = curie.expand(link_or_links['href']) if curie
-        Link.new(name, link_or_links, entry_point)
       else
         Link.new(name, link_or_links, entry_point)
       end


### PR DESCRIPTION
Re issue: #97 
https://tools.ietf.org/html/draft-kelly-json-hal-07#section-8.2
I think there is a misinterpretation of how curies are supposed to be used in HAL.  Curies are meant to shorten the key names in a _links hash, not the actual href associated with a link in the _links hash, as well as provide a link to the human readable documentation for said link.

https://tools.ietf.org/html/draft-kelly-json-hal-07#section-8.2

> 8.2.  Link relations
> 
>    Custom link relation types (Extension Relation Types in [RFC5988])
>    SHOULD be URIs that when dereferenced in a web browser provide
>    relevant documentation, in the form of an HTML page, about the
>    meaning and/or behaviour of the target Resource.  This will improve
>    the discoverability of the API.

So actually, hyperclient shouldn't be doing any template expansion when dealing with curie syntax at all when navigating to a curied link.

> The CURIE Syntax [W3C.NOTE-curie-20101216] MAY be used for brevity
>    for these URIs.  CURIEs are established within a HAL document via a
>    set of Link Objects with the relation type "curies" on the root
>    Resource Object.  These links contain a URI Template with the token
>    'rel', and are named via the "name" property.
> 
>    {
>      "_links": {
>        "self": { "href": "/orders" },
>        "curies": [{
>          "name": "acme",
>          "href": "http://docs.acme.com/relations/{rel}",
>          "templated": true
>        }],
>        "acme:widgets": { "href": "/widgets" }
>      }
>    }
> 
>    The above demonstrates the relation "http://docs.acme.com/relations/
>    widgets" being abbreviated to "acme:widgets" via CURIE syntax.
> 

When a curie is present, the href template inside the curie is how to find the documentation, not the resources. In the example above (from the spec), the resource is widgets, but the curie href refers to the documentation for wigets.

