### PR TITLE
Require Faraday >= 0.9.0 in gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 0.8.4 (Next)
 
+* [#117](https://github.com/codegram/hyperclient/issues/117): Require Faraday >= 0.9.0 in gemspec - [@ivoanjo](https://github.com/ivoanjo).
 * Your contribution here.
 
 ### 0.8.3 (March 30, 2017)

--- a/hyperclient.gemspec
+++ b/hyperclient.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.version       = Hyperclient::VERSION
 
-  gem.add_dependency 'faraday'
+  gem.add_dependency 'faraday', '>= 0.9.0'
   gem.add_dependency 'futuroscope'
   gem.add_dependency 'faraday_middleware'
   gem.add_dependency 'faraday_hal_middleware'


### PR DESCRIPTION
In #115 we started configuring Faraday to use the FlatParamsEncoder to
avoid an issue with dropped parameters when building a request url.

Unfortunately, as FlatParamsEncoder was only added on Faraday 0.9.0
we should require that version as a minimum, otherwise clients may get
confusing error messages after upgrading to the latest hyperclient
version.

Fixes #117