### PR TITLE
Add table of contents to readme and add note asking users to add their projects to the wiki

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.8.6 (Next)
 
 * [#122](https://github.com/codegram/hyperclient/pull/122): Improve error message when server returns invalid data - [@ivoanjo](https://github.com/ivoanjo).
+* [#125](https://github.com/codegram/hyperclient/pull/125): Add table of contents to readme and add note asking users to add their projects to the wiki - [@ivoanjo](https://github.com/ivoanjo).
 * Your contribution here.
 
 ### 0.8.5 (July 5, 2017)

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Hyperclient is a Hypermedia API client written in Ruby. It fully supports [JSON 
   * [Asynchronous requests](#asynchronous-requests)
 * [Testing Using Hyperclient](#testing-using-hyperclient)
 * [Reference](#reference)
+* [Hyperclient Users](#hyperclient-users)
 * [Contributing](#contributing)
 * [License](#license)
 
@@ -253,6 +254,10 @@ For a complete example refer to [this Splines Demo API test](https://github.com/
 # Reference
 
 [Hyperclient API Reference](http://rubydoc.org/github/codegram/hyperclient/master/frames).
+
+# Hyperclient Users
+
+Using Hyperclient? Add your project to our wiki, please: <https://github.com/codegram/hyperclient/wiki>.
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,28 @@
 
 Hyperclient is a Hypermedia API client written in Ruby. It fully supports [JSON HAL](http://stateless.co/hal_specification.html).
 
-## Usage
+* [Hyperclient](#hyperclient)
+* [Usage](#usage)
+  * [API Client](#api-client)
+  * [Resources and Attributes](#resources-and-attributes)
+  * [Links and Embedded Resources](#links-and-embedded-resources)
+  * [Templated Links](#templated-links)
+  * [Curies](#curies)
+  * [Attributes](#attributes)
+  * [HTTP](#http)
+  * [Asynchronous requests](#asynchronous-requests)
+* [Testing Using Hyperclient](#testing-using-hyperclient)
+* [Reference](#reference)
+* [Contributing](#contributing)
+* [License](#license)
+
+<sub><sup>ToC created with [gh-md-toc](https://github.com/ekalinin/github-markdown-toc)</sup></sub>
+
+# Usage
 
 The examples in this README use the [Splines Demo API](https://github.com/ruby-grape/grape-with-roar) running [here](https://grape-with-roar.herokuapp.com/api). If you're upgrading from a previous version, please make sure to read [UPGRADING](UPGRADING.md).
 
-### API Client
+## API Client
 
 Create an API client.
 
@@ -85,7 +102,7 @@ api = Hyperclient.new('https://grape-with-roar.herokuapp.com/api')
 api.connection.use :http_cache
 ```
 
-### Resources and Attributes
+## Resources and Attributes
 
 Hyperclient will fetch and discover the resources from your API.
 
@@ -104,7 +121,7 @@ api.splines.each do |spline|
 end
 ```
 
-### Links and Embedded Resources
+## Links and Embedded Resources
 
 The splines example above followed a link called "splines". While you can, you do not need to specify the HAL navigational structure, including links or embedded resources. Hyperclient will resolve these for you.  If you prefer, you can explicitly navigate the link structure via `_links`. In the following example the "splines" link leads to a collection of embedded splines. Invoking `api.splines` is equivalent to `api._links.splines._embedded.splines`.
 
@@ -112,7 +129,7 @@ The splines example above followed a link called "splines". While you can, you d
 api._links.splines
 ```
 
-### Templated Links
+## Templated Links
 
 Templated links require variables to be expanded. For example, the demo API has a link called "spline" that requires a spline "uuid".
 
@@ -125,7 +142,7 @@ Invoking `api.spline(uuid: 'uuid').reticulated` is equivalent to `api._links.spl
 
 The client is responsible for supplying all the necessary parameters. Templated links don't do any strict parameter name checking and don't support required vs. optional parameters. Parameters not declared by the API will be dropped and will not have any effect when passed to `_expand`.
 
-### Curies
+## Curies
 
 Curies are a suggested means by which to link documentation of a given resource. For example, the demo API contains very long links to images that use an "images" curie.
 
@@ -134,7 +151,7 @@ puts spline['image:thumbnail'] # => https://grape-with-roar.herokuapp.com/api/sp
 puts spline.links._curies['image'].expand('thumbnail') # => /docs/images/thumbnail
 ```
 
-### Attributes
+## Attributes
 
 Resource attributes can also be accessed as a hash.
 
@@ -144,7 +161,7 @@ puts spline.to_h # => {"uuid" => "uuid", "reticulated" => true}
 
 The above is equivalent to `spline._attributes.to_h`.
 
-### HTTP
+## HTTP
 
 Hyperclient uses [Faraday](http://github.com/lostisland/faraday) under the hood to perform HTTP calls. You can call any valid HTTP method on any resource.
 
@@ -187,7 +204,7 @@ spline._delete
 
 HTTP methods always return a new instance of Resource.
 
-### Asynchronous requests
+## Asynchronous requests
 
 By default, Hyperclient requests are performed asynchronously in a background thread pool via the [Futuroscope](https://github.com/codegram/futuroscope) gem. You can control the size of this pool by setting the `min_workers` and `max_workers` settings:
 
@@ -204,7 +221,7 @@ api = Hyperclient.new('https://grape-with-roar.herokuapp.com/api') do |client|
 end
 ```
 
-## Testing Using Hyperclient
+# Testing Using Hyperclient
 
 You can combine RSpec, Faraday::Adapter::Rack and Hyperclient to test your HAL API without having to ever examine the raw JSON response.
 
@@ -233,14 +250,14 @@ end
 
 For a complete example refer to [this Splines Demo API test](https://github.com/ruby-grape/grape-with-roar/blob/master/spec/api/splines_endpoint_with_hyperclient_spec.rb).
 
-## Reference
+# Reference
 
 [Hyperclient API Reference](http://rubydoc.org/github/codegram/hyperclient/master/frames).
 
-## Contributing
+# Contributing
 
 Hyperclient is work of [many people](https://github.com/codegram/hyperclient/graphs/contributors). You're encouraged to submit [pull requests](https://github.com/codegram/hyperclient/pulls), [propose features and discuss issues](https://github.com/codegram/hyperclient/issues). See [CONTRIBUTING](CONTRIBUTING.md) for details.
 
-## License
+# License
 
 MIT License, see [LICENSE](LICENSE) for details. Copyright 2012-2014 [Codegram Technologies](http://codegram.com).


### PR DESCRIPTION
As an alternative to asking users of Hyperclient on #71 to add their projects to our wiki, let's ask on our README instead.

Also, while I was in the neighbourhood, I added a table of contents to the README.