### PR TITLE
Swap yard dependency for danger-toc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.8.7 (Next)
 
 * [#131](https://github.com/codegram/hyperclient/pull/131): Upgrade to Rubocop 0.50.0, fix Bundler's insecure git source warning - [@nebolsin](https://github.com/nebolsin).
+* [#132](https://github.com/codegram/hyperclient/pull/132): Swapped yard dependency for danger-toc - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 ### 0.8.6 (August 27, 2017)

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,2 +1,2 @@
-# check for changes in CHANGELOG
 changelog.check
+toc.check

--- a/Gemfile
+++ b/Gemfile
@@ -18,12 +18,11 @@ group :development, :test do
   gem 'rake'
   gem 'rubocop', '~> 0.50.0', require: false
   gem 'simplecov', require: false
-  gem 'yard', '~> 0.8'
-  gem 'yard-tomdoc'
 end
 
 group :test do
   gem 'danger-changelog', '~> 0.1'
+  gem 'danger-toc', '~> 0.1'
   gem 'futuroscope', github: 'codegram/futuroscope'
   gem 'minitest'
   gem 'mocha'

--- a/README.md
+++ b/README.md
@@ -8,23 +8,22 @@
 
 Hyperclient is a Hypermedia API client written in Ruby. It fully supports [JSON HAL](http://stateless.co/hal_specification.html).
 
-* [Hyperclient](#hyperclient)
-* [Usage](#usage)
-  * [API Client](#api-client)
-  * [Resources and Attributes](#resources-and-attributes)
-  * [Links and Embedded Resources](#links-and-embedded-resources)
-  * [Templated Links](#templated-links)
-  * [Curies](#curies)
-  * [Attributes](#attributes)
-  * [HTTP](#http)
-  * [Asynchronous requests](#asynchronous-requests)
-* [Testing Using Hyperclient](#testing-using-hyperclient)
-* [Reference](#reference)
-* [Hyperclient Users](#hyperclient-users)
-* [Contributing](#contributing)
-* [License](#license)
+# Table of Contents
 
-<sub><sup>ToC created with [gh-md-toc](https://github.com/ekalinin/github-markdown-toc)</sup></sub>
+- [Usage](#usage)
+  - [API Client](#api-client)
+  - [Resources and Attributes](#resources-and-attributes)
+  - [Links and Embedded Resources](#links-and-embedded-resources)
+  - [Templated Links](#templated-links)
+  - [Curies](#curies)
+  - [Attributes](#attributes)
+  - [HTTP](#http)
+  - [Asynchronous requests](#asynchronous-requests)
+- [Testing Using Hyperclient](#testing-using-hyperclient)
+- [Reference](#reference)
+- [Hyperclient Users](#hyperclient-users)
+- [Contributing](#contributing)
+- [License](#license)
 
 # Usage
 

--- a/Rakefile
+++ b/Rakefile
@@ -13,13 +13,6 @@ if ENV['COVERAGE']
   end
 end
 
-require 'yard'
-YARD::Config.load_plugin('yard-tomdoc')
-YARD::Rake::YardocTask.new do |t|
-  t.files   = ['lib/**/*.rb']
-  t.options = %w[-r README.md]
-end
-
 require 'rake/testtask'
 
 Rake::TestTask.new(:test) do |t|


### PR DESCRIPTION
This avoids having to worry about the TOC every time and developers modifying the sections in README get alerted to a broken TOC.  