### PR TITLE
Fix validation for empty body responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Your contribution here.
 * [#136](https://github.com/codegram/hyperclient/pull/136): Fix danger warnings for changelog - [@ivoanjo](https://github.com/ivoanjo).
+* [#135](https://github.com/codegram/hyperclient/pull/135): Fix validation for empty body responses - [@paulocdf](https://github.com/paulocdf).
 
 ### 0.9.0 (2018/01/10)
 

--- a/lib/hyperclient/resource.rb
+++ b/lib/hyperclient/resource.rb
@@ -82,7 +82,7 @@ module Hyperclient
 
     # Internal: Ensures the received representation is a valid Hash-lookalike.
     def validate(representation)
-      return {} unless representation
+      return {} if representation.nil? || representation.empty?
 
       if representation.respond_to?(:to_hash)
         representation.to_hash.dup

--- a/test/hyperclient/resource_test.rb
+++ b/test/hyperclient/resource_test.rb
@@ -41,6 +41,16 @@ module Hyperclient
         resource._response.body.must_equal body
       end
 
+      describe 'with an empty body in response' do
+        it 'initializes the response' do
+          mock_response = mock(body: '')
+
+          resource = Resource.new(mock_response.body, entry_point, mock_response)
+
+          resource._response.must_equal mock_response
+        end
+      end
+
       describe 'with an invalid representation' do
         it 'raises an InvalidRepresentationError' do
           proc { Resource.new('invalid representation data', entry_point) }.must_raise InvalidRepresentationError


### PR DESCRIPTION
This PR fixes the situation where responses from a server that do not have a body throw an `InvalidRepresentationError`. This situation is common for DELETE requests where the 204 (No Content) is a valid response.

The `validate` method was changed to return an empty hash if the given `representation` is `nil` or an empty string.

