### PR TITLE
Fix danger warnings for changelog

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ matrix:
         - bundle exec danger
     - rvm: jruby-9.1.12.0
     - rvm: jruby-head
-    - rvm: 2.2.7
     - rvm: 2.3.4
     - rvm: rbx-2
     - rvm: ruby-head

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,73 +1,76 @@
+## Changelog
+
 ### 0.9.1 (Next)
 
 * Your contribution here.
+* [#136](https://github.com/codegram/hyperclient/pull/136): Fix danger warnings for changelog - [@ivoanjo](https://github.com/ivoanjo).
 
-### 0.9.0 (January 10, 2018)
+### 0.9.0 (2018/01/10)
 
 * [#133](https://github.com/codegram/hyperclient/pull/133): Removed futuroscope - [@dblock](https://github.com/dblock).
 * [#131](https://github.com/codegram/hyperclient/pull/131): Upgrade to Rubocop 0.50.0, fix Bundler's insecure git source warning - [@nebolsin](https://github.com/nebolsin).
 * [#132](https://github.com/codegram/hyperclient/pull/132): Swapped yard dependency for danger-toc - [@dblock](https://github.com/dblock).
 
-### 0.8.6 (August 27, 2017)
+### 0.8.6 (2017/08/27)
 
 * [#122](https://github.com/codegram/hyperclient/pull/122): Improve error message when server returns invalid data - [@ivoanjo](https://github.com/ivoanjo).
 * [#125](https://github.com/codegram/hyperclient/pull/125): Add table of contents to readme and add note asking users to add their projects to the wiki - [@ivoanjo](https://github.com/ivoanjo).
 * [#127](https://github.com/codegram/hyperclient/pull/127): Minor fixes: Fix warnings, and pry-byebug to dev Gemfile and tweak rubocop execution - [@ivoanjo](https://github.com/ivoanjo).
 * [#128](https://github.com/codegram/hyperclient/pull/128): Fix link delegation returning nil for field with value false - [@ivoanjo](https://github.com/ivoanjo).
 
-### 0.8.5 (July 5, 2017)
+### 0.8.5 (2017/07/05)
 
 * [#120](https://github.com/codegram/hyperclient/pull/120): Replace non-working homepage link in gemspec - [@ivoanjo](https://github.com/ivoanjo).
 
-### 0.8.4 (May 16, 2017)
+### 0.8.4 (2017/05/16)
 
 * [#117](https://github.com/codegram/hyperclient/issues/117): Require Faraday >= 0.9.0 in gemspec - [@ivoanjo](https://github.com/ivoanjo).
 
-### 0.8.3 (March 30, 2017)
+### 0.8.3 (2017/03/30)
 
 * [#115](https://github.com/codegram/hyperclient/pull/115): Fix dropped values from queries by using FlatParamsEncoder - [@ivoanjo](https://github.com/ivoanjo).
 
-### 0.8.2 (December 31, 2016)
+### 0.8.2 (2016/12/31)
 
-#### This version is no longer tested with Ruby < 2.2.
+* NOTE: **⚠ This version is no longer tested with Ruby < 2.2 ⚠** - [@dblock](https://github.com/dblock).
 
 * [#105](https://github.com/codegram/hyperclient/pull/105), [#108](https://github.com/codegram/hyperclient/pull/108): Added Danger, PR linter - [@dblock](https://github.com/dblock).
 * [#109](https://github.com/codegram/hyperclient/pull/109): Allow disabling asynchronous behavior per-instance - [@Talkdesk](https://github.com/Talkdesk).
 * [#110](https://github.com/codegram/hyperclient/pull/110): Fixed ruby warnings - [@ivoanjo](https://github.com/ivoanjo).
 
-### 0.8.1 (March 15, 2016)
+### 0.8.1 (2016/03/15)
 
 * [#97](https://github.com/codegram/hyperclient/issues/97): Fix: curies are no longer used as link shorteners - [@joshco](https://github.com/joshco), [@dblock](https://github.com/dblock).
 * [#95](https://github.com/codegram/hyperclient/issues/95): Fix: re-add eager delegation for `resource.each` - [@dblock](https://github.com/dblock).
 
-### 0.7.2 (August 23, 2015)
+### 0.7.2 (2015/08/23)
 
 * [#95](https://github.com/codegram/hyperclient/issues/95): Fix: re-add eager delegation for `resource.x._embeddded.x` - [@dblock](https://github.com/dblock).
 
-### 0.7.1 (August 15, 2015)
+### 0.7.1 (2015/08/15)
 
 * [#89](https://github.com/codegram/hyperclient/issues/89): Added `Hyperclient::Resource#fetch` - [@alabeduarte](https://github.com/alabeduarte).
 * [#87](https://github.com/codegram/hyperclient/pull/87): Fix: eager delegation causes link skipping - [@dblock](https://github.com/dblock).
 
-### 0.7.0 (February 23, 2015)
+### 0.7.0 (2015/02/23)
 
-#### This version introduces several backwards incompatible changes. See [UPGRADING](UPGRADING.md) for details.
+* NOTE: **⚠ This version introduces several backwards incompatible changes. See [UPGRADING](UPGRADING.md) for details ⚠** - [@dblock](https://github.com/dblock).
 
 * [#80](https://github.com/codegram/hyperclient/pull/80): Faraday options can be passed to the connection on initialization - [@koenpunt](https://github.com/koenpunt).
 * [#81](https://github.com/codegram/hyperclient/pull/81): The default Content-Type is now `application/hal+json` - [@koenpunt](https://github.com/koenpunt).
 
-### 0.6.1 (October 17, 2014)
+### 0.6.1 (2014/10/17)
 
-#### This version introduces several backwards incompatible changes. See [UPGRADING](UPGRADING.md) for details.
+* NOTE: **⚠ This version introduces several backwards incompatible changes. See [UPGRADING](UPGRADING.md) for details ⚠** - [@dblock](https://github.com/dblock).
 
 * [#51](https://github.com/codegram/hyperclient/issues/51), [#75](https://github.com/codegram/hyperclient/pull/75): Added support for setting headers and overriding or extending the default Faraday connection block before a connection is constructed - [@dblock](https://github.com/dblock).
 * [#41](https://github.com/codegram/hyperclient/issues/41), [#73](https://github.com/codegram/hyperclient/pull/73): All Link HTTP methods now return a Resource, including `_get`, which has been aliased to `_resource`, `_post`, `_put`, `_patch`, `_head` and `_options` - [@dblock](https://github.com/dblock).
 * [#72](https://github.com/codegram/hyperclient/pull/72): The default Faraday block now uses `Faraday::Response::RaiseError` and will cause HTTP errors to be raised as exceptions - [@dblock](https://github.com/dblock).
 * [#77](https://github.com/codegram/hyperclient/pull/77): Added support for templated links with all optional arguments - [@dblock](https://github.com/dblock).
 
-### 0.5.0 (October 1, 2014)
+### 0.5.0 (2014/10/01)
 
-#### This version introduces several backwards incompatible changes. See [UPGRADING](UPGRADING.md) for details.
+* NOTE: **⚠ This version introduces several backwards incompatible changes. See [UPGRADING](UPGRADING.md) for details ⚠** - [@dblock](https://github.com/dblock).
 
 * [#63](https://github.com/codegram/hyperclient/pull/63): Navigational methods, including `links`, `get` or `post`, have been renamed to `_links`, `_get`, or `_post` respectively - [@dblock](https://github.com/dblock).
 * [#64](https://github.com/codegram/hyperclient/issues/64): Added support for curies - [@dblock](https://github.com/dblock).
@@ -75,12 +78,12 @@
 * [#63](https://github.com/codegram/hyperclient/pull/63): You can omit the navigational elements, `api.links.products` is now equivalent to `api.products` - [@dblock](https://github.com/dblock).
 * [#61](https://github.com/codegram/hyperclient/pull/61): Implemented Rubocop, Ruby-style linter - [@dblock](https://github.com/dblock).
 
-### 0.4.0 (May 5, 2014)
+### 0.4.0 (2014/05/05)
 
 * [#54](https://github.com/codegram/hyperclient/pull/54): Support Faraday 0.9.0 - [@lucianapazos](https://github.com/lucianapazos).
 * [#30](https://github.com/codegram/hyperclient/pull/30): Use futuroscope to run API calls in the background - [@josepjaume](https://github.com/josepjaume).
 
-### 0.3.2 (December 20, 2013)
+### 0.3.2 (2013/12/20)
 
 * [#48](https://github.com/codegram/hyperclient/pull/48): Added support for fetch on the collection class - [@col](https://github.com/col).
 * [#50](https://github.com/codegram/hyperclient/pull/50): Fixed Resource/Attributes mutating the response body - [@col](https://github.com/col).
@@ -94,10 +97,10 @@
 * [#31](https://github.com/codegram/hyperclient/pull/31): Allowed underscored attribute names other than the ones reserved by the HAL spec - [@karlin](https://github.com/karlin).
 * [#29](https://github.com/codegram/hyperclient/pull/29): Handled JSON that includes a link with a null value - [@arbylee](https://github.com/arbylee).
 
-### 0.3.1 (April 3, 2013)
+### 0.3.1 (2013/04/03)
 
 * [#27](https://github.com/codegram/hyperclient/pull/27): Added support for collections of links - [@rehevkor5](https://github.com/rehevkor5).
 
-### 0.3.0 (February 3, 2013)
+### 0.3.0 (2013/02/03)
 
 * Initial public release - [@oriolgual](https://github.com/oriolgual).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### 0.9.1 (Next)
 
+* NOTE: **⚠ This version is no longer tested with Ruby < 2.3 ⚠** - [@ivoanjo](https://github.com/ivoanjo).
+
 * Your contribution here.
 * [#136](https://github.com/codegram/hyperclient/pull/136): Fix danger warnings for changelog - [@ivoanjo](https://github.com/ivoanjo).
 


### PR DESCRIPTION
I've fixed the date formats, as well as the extra notes.

@dblock I just noticed that you own https://github.com/dblock/danger-changelog/ and I think it's missing a bit of documentation around what it considers a well-formed changelog (e.g. showing off all of the possible use cases, or a "complex" changelog).

Getting it to accept hyperclient's `CHANGELOG` again was a bit trial-and-error as the error message was a bit too generic.