### PR TITLE
Update Travis matrix to use latest Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,10 @@ matrix:
     - rvm: jruby-9.1.12.0
     - rvm: jruby-head
     - rvm: 2.3.8
-    - rvm: rbx-2
     - rvm: ruby-head
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
-    - rvm: rbx-2
 
 before_install:
   - gem update --system

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
     - rvm: 2.4.6
       script:
         - bundle exec danger
-    - rvm: jruby-9.1.12.0
+    - rvm: jruby-9.2.7.0
     - rvm: jruby-head
     - rvm: 2.3.8
     - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,15 @@ sudo: false
 
 matrix:
   include:
-    - rvm: 2.4.1
-    - rvm: 2.4.1
+    - rvm: 2.6.3
+    - rvm: 2.5.5
+    - rvm: 2.4.6
+    - rvm: 2.4.6
       script:
         - bundle exec danger
     - rvm: jruby-9.1.12.0
     - rvm: jruby-head
-    - rvm: 2.3.4
+    - rvm: 2.3.8
     - rvm: rbx-2
     - rvm: ruby-head
   allow_failures:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Your contribution here.
 * [#136](https://github.com/codegram/hyperclient/pull/136): Fix danger warnings for changelog - [@ivoanjo](https://github.com/ivoanjo).
 * [#135](https://github.com/codegram/hyperclient/pull/135): Fix validation for empty body responses - [@paulocdf](https://github.com/paulocdf).
+* [#139](https://github.com/codegram/hyperclient/pull/139): Test `hyperclient` against newer versions of MRI Ruby, up unitl 2.6.x - [@mrcasals](https://github.com/mrcasals).
 
 ### 0.9.0 (2018/01/10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Your contribution here.
 * [#136](https://github.com/codegram/hyperclient/pull/136): Fix danger warnings for changelog - [@ivoanjo](https://github.com/ivoanjo).
 * [#135](https://github.com/codegram/hyperclient/pull/135): Fix validation for empty body responses - [@paulocdf](https://github.com/paulocdf).
-* [#139](https://github.com/codegram/hyperclient/pull/139): Test `hyperclient` against newer versions of MRI Ruby, up unitl 2.6.x - [@mrcasals](https://github.com/mrcasals).
+* [#139](https://github.com/codegram/hyperclient/pull/139): Test `hyperclient` against newer versions of MRI Ruby, up until 2.6.x - [@mrcasals](https://github.com/mrcasals).
 
 ### 0.9.0 (2018/01/10)
 

--- a/test/fixtures/element.json
+++ b/test/fixtures/element.json
@@ -3,8 +3,8 @@
         "self": {
             "href": "/productions/1"
         },
-        "filter": {
-            "href": "/productions/1?categories={filter}",
+        "search": {
+            "href": "/productions/1?categories={search}",
             "templated": true
         },
         "gizmos": [
@@ -15,17 +15,17 @@
                 "href": "/gizmos/2"
             }
         ],
-        "curies" : [
+        "curies": [
             {
-              "name": "image",
-              "href": "/docs/images/{rel}",
-              "templated": true
+                "name": "image",
+                "href": "/docs/images/{rel}",
+                "templated": true
             }
         ],
         "null_link": null,
         "image:thumbnail": {
-          "href": "/images/thumbnails/{version}.jpg",
-          "templated": true
+            "href": "/images/thumbnails/{version}.jpg",
+            "templated": true
         }
     },
     "title": "Real World ASP.NET MVC3",
@@ -48,9 +48,9 @@
                         "href": "/episodes/1"
                     },
                     "media": {
-                            "type": "video/webm; codecs='vp8.0, vorbis'",
-                            "href": "/media/1"
-                        }
+                        "type": "video/webm; codecs='vp8.0, vorbis'",
+                        "href": "/media/1"
+                    }
                 },
                 "title": "Foundations",
                 "description": "In this episode we talk about what it is we're doing: building our startup and getting ourselves off the ground. We take..",
@@ -62,9 +62,9 @@
                         "href": "/episodes/2"
                     },
                     "media": {
-                            "type": "video/ogg; codecs='theora, vorbis'",
-                            "href": "/media/4"
-                        }
+                        "type": "video/ogg; codecs='theora, vorbis'",
+                        "href": "/media/4"
+                    }
                 },
                 "title": "Membership",
                 "description": "In this episode Rob hooks up testing in an effort to deal with ASP.NET Membership. The team has decided..",

--- a/test/hyperclient/link_collection_test.rb
+++ b/test/hyperclient/link_collection_test.rb
@@ -18,12 +18,12 @@ module Hyperclient
     end
 
     it 'initializes the collection with links' do
-      links.must_respond_to :filter
+      links.must_respond_to :search
       links.must_respond_to :gizmos
     end
 
     it 'returns link objects for each link' do
-      links.filter.must_be_kind_of Link
+      links.search.must_be_kind_of Link
       links['self'].must_be_kind_of Link
 
       links.gizmos.must_be_kind_of Array
@@ -38,9 +38,9 @@ module Hyperclient
     end
 
     describe 'templated link' do
-      let(:templated_link) { links.filter }
+      let(:templated_link) { links.search }
       it 'must expand' do
-        templated_link._expand(filter: 'gizmos')._url.must_equal '/productions/1?categories=gizmos'
+        templated_link._expand(search: 'gizmos')._url.must_equal '/productions/1?categories=gizmos'
       end
     end
 


### PR DESCRIPTION
This PR updates the Travis matrix to use the latest released versions of MRI Ruby, up until Ruby 2.6.x (2.6.3).