### PR TITLE
Replace `uri_template` with `addressable` library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#136](https://github.com/codegram/hyperclient/pull/136): Fix danger warnings for changelog - [@ivoanjo](https://github.com/ivoanjo).
 * [#135](https://github.com/codegram/hyperclient/pull/135): Fix validation for empty body responses - [@paulocdf](https://github.com/paulocdf).
 * [#139](https://github.com/codegram/hyperclient/pull/139): Test `hyperclient` against newer versions of MRI Ruby, up until 2.6.x - [@mrcasals](https://github.com/mrcasals).
+* [#141](https://github.com/codegram/hyperclient/pull/141): Replace `uri_template` with `addressable` library - [@mrcasals](https://github.com/mrcasals).
 
 ### 0.9.0 (2018/01/10)
 

--- a/hyperclient.gemspec
+++ b/hyperclient.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'faraday', '>= 0.9.0'
   gem.add_dependency 'faraday_middleware'
   gem.add_dependency 'faraday_hal_middleware'
-  gem.add_dependency 'uri_template'
+  gem.add_dependency 'addressable'
   gem.add_dependency 'net-http-digest_auth'
   gem.add_dependency 'faraday-digestauth'
 end

--- a/lib/hyperclient/link.rb
+++ b/lib/hyperclient/link.rb
@@ -1,4 +1,4 @@
-require 'uri_template'
+require 'addressable'
 
 module Hyperclient
   # Internal: The Link is used to let a Resource interact with the API.
@@ -39,7 +39,7 @@ module Hyperclient
     # Public: Returns the url of the Link.
     def _url
       return @link['href'] unless _templated?
-      @url ||= _uri_template.expand(@uri_variables || {})
+      @url ||= _uri_template.expand(@uri_variables || {}).to_s
     end
 
     # Public: Returns an array of variables from the URITemplate.
@@ -162,7 +162,7 @@ module Hyperclient
 
     # Internal: Memoization for a URITemplate instance
     def _uri_template
-      @uri_template ||= URITemplate.new(@link['href'])
+      @uri_template ||= Addressable::Template.new(@link['href'])
     end
 
     def http_method(method, body = nil)


### PR DESCRIPTION
`uri_template` was causing some load errors on test and had no new
releases for years, so we'd better use a newer library that does the
same job.

See an example of a build with load errors:

https://travis-ci.org/codegram/hyperclient/jobs/555752699#L803