### PR TITLE
Drop the turn dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,5 @@ group :test do
   gem 'mocha'
   gem 'rack-test'
   gem 'spinach'
-  gem 'turn'
   gem 'webmock'
 end

--- a/test/hyperclient/link_test.rb
+++ b/test/hyperclient/link_test.rb
@@ -16,7 +16,7 @@ module Hyperclient
 
         it 'returns nil if the property is not present' do
           link = Link.new('key', {}, entry_point)
-          link.send("_#{prop}").must_equal nil
+          link.send("_#{prop}").must_be_nil
         end
       end
     end
@@ -301,7 +301,7 @@ module Hyperclient
           end
 
           resource.foos._embedded.orders.first.id.must_equal 1
-          resource.foos.first.must_equal nil
+          resource.foos.first.must_be_nil
         end
 
         it 'backtracks when navigating links' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,12 +1,11 @@
 $LOAD_PATH << 'lib'
 
-require 'minitest/spec'
 require 'minitest/autorun'
+require 'minitest/pride'
 require 'mocha/setup'
-require 'turn'
 require 'json'
 
-MiniTest::Unit::TestCase.class_eval do
+MiniTest::Test.class_eval do
   def stub_request(conn, adapter_class = Faraday::Adapter::Test, &stubs_block)
     adapter_handler = conn.builder.handlers.find { |h| h.klass < Faraday::Adapter }
     conn.builder.swap(adapter_handler, adapter_class, &stubs_block)


### PR DESCRIPTION
It seems like the `tern` gem is no longe maintained and I couldn't run the test suite after "bundle update", because `Turn` thinks that minitest 5.11.3 is out of date even though [it is the latest one](https://rubygems.org/gems/minitest/versions):

```
Traceback (most recent call last):
	10: from /Users/yuki/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rake-12.3.3/lib/rake/rake_test_loader.rb:5:in `<main>'
	 9: from /Users/yuki/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rake-12.3.3/lib/rake/rake_test_loader.rb:5:in `select'
	 8: from /Users/yuki/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rake-12.3.3/lib/rake/rake_test_loader.rb:17:in `block in <main>'
	 7: from /Users/yuki/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rake-12.3.3/lib/rake/rake_test_loader.rb:17:in `require'
	 6: from /Users/yuki/GitHub/hyperclient/test/faraday/connection_test.rb:1:in `<top (required)>'
	 5: from /Users/yuki/GitHub/hyperclient/test/faraday/connection_test.rb:1:in `require_relative'
	 4: from /Users/yuki/GitHub/hyperclient/test/test_helper.rb:6:in `<top (required)>'
	 3: from /Users/yuki/GitHub/hyperclient/test/test_helper.rb:6:in `require'
	 2: from /Users/yuki/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/turn-0.9.6/lib/turn.rb:13:in `<top (required)>'
	 1: from /Users/yuki/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/turn-0.9.6/lib/turn.rb:13:in `require'
/Users/yuki/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/turn-0.9.6/lib/turn/minitest.rb:22:in `<top (required)>': MiniTest v5.11.3 is out of date. (RuntimeError)
`gem install minitest` and add `gem 'minitest' to you test helper.
```

The latest version of `turn` has a constraint on the minitest gem `~> 4`, which is more than 5 years old. I don't think we should use that. As a replacement I just added `require 'minitest/pride'` to make it a little colorful.

Here is a screenshot of the output from the new setup:

<img width="1419" alt="Screen Shot 2019-08-22 at 10 25 52 PM" src="https://user-images.githubusercontent.com/386234/63562518-efdcc780-c52b-11e9-804f-9bc6dc59850a.png">
