### PR TITLE
Upgraded Danger plugins.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 * NOTE: **⚠ This version is no longer tested with Ruby < 2.3 ⚠** - [@ivoanjo](https://github.com/ivoanjo).
 
-* Your contribution here.
-* [#136](https://github.com/codegram/hyperclient/pull/136): Fix danger warnings for changelog - [@ivoanjo](https://github.com/ivoanjo).
 * [#135](https://github.com/codegram/hyperclient/pull/135): Fix validation for empty body responses - [@paulocdf](https://github.com/paulocdf).
 * [#139](https://github.com/codegram/hyperclient/pull/139): Test `hyperclient` against newer versions of MRI Ruby, up until 2.6.x - [@mrcasals](https://github.com/mrcasals).
 * [#141](https://github.com/codegram/hyperclient/pull/141): Replace `uri_template` with `addressable` library - [@mrcasals](https://github.com/mrcasals).
+* [#136](https://github.com/codegram/hyperclient/pull/136), [#146](https://github.com/codegram/hyperclient/pull/146): Upgraded Danger plugins - [@dblock](https://github.com/dblock), [@ivoanjo](https://github.com/ivoanjo).
+* Your contribution here.
 
 ### 0.9.0 (2018/01/10)
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,2 +1,2 @@
-changelog.check
-toc.check
+changelog.check!
+toc.check!

--- a/Gemfile
+++ b/Gemfile
@@ -21,8 +21,8 @@ group :development, :test do
 end
 
 group :test do
-  gem 'danger-changelog', '~> 0.1'
-  gem 'danger-toc', '~> 0.1'
+  gem 'danger-changelog', '~> 0.6.0'
+  gem 'danger-toc', '~> 0.2.0'
   gem 'minitest'
   gem 'mocha'
   gem 'rack-test'


### PR DESCRIPTION
Debugging Danger error from https://github.com/codegram/hyperclient/pull/145.