### PR TITLE
Address Faraday warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 0.9.2 (Next)
 
+* [#149](https://github.com/codegram/hyperclient/pull/149): Address Faraday warnings - [@yuki24](https://github.com/yuki24).
 * Your contribution here.
 
 ### 0.9.1 (2019/08/25)

--- a/lib/hyperclient/entry_point.rb
+++ b/lib/hyperclient/entry_point.rb
@@ -62,8 +62,7 @@ module Hyperclient
                            block
                          else
                            lambda do |conn|
-                             default_faraday_block.call conn
-                             yield conn
+                             default_faraday_block.call(conn, &block)
                            end
                          end
       else
@@ -138,11 +137,14 @@ module Hyperclient
     #
     # Returns a block.
     def default_faraday_block
-      lambda do |connection|
+      lambda do |connection, &block|
         connection.use Faraday::Response::RaiseError
         connection.use FaradayMiddleware::FollowRedirects
         connection.request :hal_json
         connection.response :hal_json, content_type: /\bjson$/
+
+        block&.call(connection)
+
         connection.adapter :net_http
         connection.options.params_encoder = Faraday::FlatParamsEncoder
       end

--- a/test/hyperclient/entry_point_test.rb
+++ b/test/hyperclient/entry_point_test.rb
@@ -26,7 +26,14 @@ module Hyperclient
 
         it 'can insert additional middleware after a connection has been constructed' do
           entry_point.connection.must_be_kind_of Faraday::Connection
-          entry_point.connection.use :instrumentation
+
+          warning = 'WARNING: Unexpected middleware set after the adapter. ' \
+                    "This won't be supported from Faraday 1.0.\n"
+
+          assert_output nil, warning do
+            entry_point.connection.use :instrumentation
+          end
+
           handlers = entry_point.connection.builder.handlers
           handlers.must_include FaradayMiddleware::Instrumentation
         end


### PR DESCRIPTION
There is a warning message from Faraday, suggesting that :

```
WARNING: Unexpected middleware set after the adapter. This won't be supported from Faraday 1.0.
```

It seems like strting version 1.0 Faraday no longer will allow for setting middleware once the adapter is set: https://github.com/lostisland/faraday/pull/685, so I moved the bock call into the `default_faraday_block` lambda.
