### PR TITLE
Lock SimpleCov to < 1.1.0 to fix coveralls CI failure

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,9 @@ group :development, :test do
   gem 'rubocop', '~> 1.89.0', require: false
   gem 'rubocop-minitest', require: false
   gem 'rubocop-rake', require: false
-  gem 'simplecov', require: false
+  # TODO: remove version constraint once coverallsapp/coverage-reporter supports float timestamps
+  # https://github.com/coverallsapp/github-action/issues/269
+  gem 'simplecov', '< 1.1.0', require: false
   gem 'simplecov-lcov', require: false
 end
 


### PR DESCRIPTION
SimpleCov 1.1.0 changed the `created_at` field in `.resultset.json` from an integer to a float timestamp. `coveralls-ruby-adapter`/`coverage-reporter` fails to parse that float, breaking the `coverage` GitHub Actions workflow on every push:

```
#<JSON::SerializableError:Couldn't parse (Int64 | Nil) from 1786493375.0592227 at line 1, column 3871
  parsing CoverageReporter::SimplecovParser::Report#timestamp at line 1, column 3859>
```

See https://github.com/coverallsapp/github-action/issues/269 for the upstream issue and root cause.

This locks `simplecov` to `< 1.1.0` (the last release before the regression) until coveralls fixes float-timestamp parsing.

Example failing run: https://github.com/codegram/hyperclient/actions/runs/31549159260/job/93967850389