### PR TITLE
Revert "Lock SimpleCov to < 1.1.0 to fix coveralls CI failure"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,9 +16,7 @@ group :development, :test do
   gem 'rubocop', '~> 1.89.0', require: false
   gem 'rubocop-minitest', require: false
   gem 'rubocop-rake', require: false
-  # TODO: remove version constraint once coverallsapp/coverage-reporter supports float timestamps
-  # https://github.com/coverallsapp/github-action/issues/269
-  gem 'simplecov', '< 1.1.0', require: false
+  gem 'simplecov', require: false
   gem 'simplecov-lcov', require: false
 end
 


### PR DESCRIPTION
Reverts #314.